### PR TITLE
Fix bug causing fluidly weight items to not sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Simple menu manager v1.0.0
+# Simple menu manager v1.2.0
 
 [![Build Status](https://travis-ci.org/deringer/simple-menu.svg?branch=master)](https://travis-ci.org/deringer/simple-menu)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/deringer/simple-menu/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/deringer/simple-menu/?branch=master)
@@ -63,16 +63,12 @@ $menu->link('Active link', 'http://example.com/active-link')->active();
 
 The package ships with a default unordered list presenter.
 
-Should you want to create your own, you may do so by implementing the `Iatstuti\SimpleMenu\Presenters\MenuPresenter` interface, providing a `render` method.
+Should you want to create your own, you may do so by implementing the `Iatstuti\SimpleMenu\Presenters\MenuPresenter` interface, providing a `render` method. The `Menu` object should be provided via the presenter's constructor.
 
 This method ought to iterate over the items in your menu, recursively rendering any objects of type `Menu` and displaying any of type `MenuItem` directly.
 
 ```php
-use Iatstuti\SimpleMenu\Presenters\UnorderedListPresenter;
-
-$presenter = new UnorderedListPresenter;
-
-print $presenter->render($menu);
+print $menu->render();
 ```
 
 ```html

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -37,11 +37,6 @@ class Menu
     protected $label;
 
     /**
-     * @var \Iatstuti\SimpleMenu\Presenters\MenuPresenter
-     */
-    protected $presenter;
-
-    /**
      * @var array
      */
     private $options;

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -2,6 +2,8 @@
 
 namespace Iatstuti\SimpleMenu;
 
+use Iatstuti\SimpleMenu\Presenters\MenuPresenter;
+use Iatstuti\SimpleMenu\Presenters\UnorderedListPresenter;
 use Iatstuti\SimpleMenu\Traits\FetchesWeight;
 use Iatstuti\SimpleMenu\Traits\ObjectOptions;
 use Iatstuti\Support\Traits\MethodPropertyAccess;
@@ -82,8 +84,6 @@ class Menu
 
         $this->items()->push($item);
 
-        $this->sortItems();
-
         return $item;
     }
 
@@ -95,6 +95,8 @@ class Menu
      */
     public function items()
     {
+        $this->sortItems();
+
         return $this->items;
     }
 
@@ -123,8 +125,36 @@ class Menu
     {
         $this->items->push($menu);
 
+        return $menu;
+    }
+
+
+    /**
+     * Render the menu using the given presenter,
+     * or the default UnorderedListPresenter.
+     *
+     * @param  \Iatstuti\SimpleMenu\Presenters\MenuPresenter|null $presenter
+     *
+     * @return string
+     */
+    public function render(MenuPresenter $presenter = null)
+    {
         $this->sortItems();
 
-        return $menu;
+        $presenter = $presenter ?: new UnorderedListPresenter($this);
+
+        return $presenter->render();
+    }
+
+
+    /**
+     * Overload the __toString method to be able to
+     * print this object using the render method.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->render();
     }
 }

--- a/src/Presenters/MenuPresenter.php
+++ b/src/Presenters/MenuPresenter.php
@@ -2,8 +2,6 @@
 
 namespace Iatstuti\SimpleMenu\Presenters;
 
-use Iatstuti\SimpleMenu\Menu;
-
 /**
  * Define the interface for a menu presenter.
  *
@@ -17,9 +15,7 @@ interface MenuPresenter
     /**
      * Render the given menu.
      *
-     * @param  \Iatstuti\SimpleMenu\Menu $menu
-     *
-     * @return mixed
+     * @return string
      */
-    public function render(Menu $menu);
+    public function render();
 }

--- a/src/Presenters/UnorderedListPresenter.php
+++ b/src/Presenters/UnorderedListPresenter.php
@@ -16,20 +16,34 @@ class UnorderedListPresenter implements MenuPresenter
 {
 
     /**
-     * Render the given menu as an unordered list.
+     * @var \Iatstuti\SimpleMenu\Menu
+     */
+    protected $menu;
+
+
+    /**
+     * UnorderedListPresenter constructor.
      *
-     * @param  \Iatstuti\SimpleMenu\Menu $menu
+     * @param \Iatstuti\SimpleMenu\Menu $menu
+     */
+    public function __construct(Menu $menu)
+    {
+        $this->menu = $menu;
+    }
+
+    /**
+     * Render the given menu as an unordered list.
      *
      * @return string
      */
-    public function render(Menu $menu)
+    public function render()
     {
         $output  = '<ul>';
 
-        foreach ($menu->items() as $item) {
+        foreach ($this->menu->items() as $item) {
             if ($item instanceof Menu) {
                 // Have a new instance of this presenter render the nested/submenu item
-                $output .= sprintf('<li>%s%s</li>', $item->label, (new static)->render($item));
+                $output .= sprintf('<li>%s%s</li>', $item->label, (new static($item))->render());
             } else if ($item instanceof MenuItem) {
                 // Render the link as-is
                 $output .= sprintf(

--- a/tests/SimpleMenuTest.php
+++ b/tests/SimpleMenuTest.php
@@ -95,7 +95,7 @@ class SimpleMenuTest extends PHPUnit_Framework_TestCase
         $menu->link('Third link', 'http://test.suite/third-link', [ 'weight' => 10, ]);
 
         $this->assertCount(3, $menu->items());
-        $this->assertSame('<ul><li><a href="http://test.suite/third-link" title="Third link">Third link</a></li><li><a href="http://test.suite/first-link" title="First link">First link</a></li><li><a href="http://test.suite/second-link" title="Second link">Second link</a></li></ul>', (new UnorderedListPresenter)->render($menu));
+        $this->assertSame('<ul><li><a href="http://test.suite/third-link" title="Third link">Third link</a></li><li><a href="http://test.suite/first-link" title="First link">First link</a></li><li><a href="http://test.suite/second-link" title="Second link">Second link</a></li></ul>', $menu->render());
     }
 
 
@@ -113,7 +113,7 @@ class SimpleMenuTest extends PHPUnit_Framework_TestCase
         $menu->subMenu($submenu);
 
         $this->assertCount(2, $menu->items());
-        $this->assertSame('<ul><li>First submenu link<ul><li><a href="http://test.suite/first-submenu-link" title="First submenu link">First submenu link</a></li></ul></li><li><a href="http://test.suite/first-link" title="First link">First link</a></li></ul>', (new UnorderedListPresenter)->render($menu));
+        $this->assertSame('<ul><li>First submenu link<ul><li><a href="http://test.suite/first-submenu-link" title="First submenu link">First submenu link</a></li></ul></li><li><a href="http://test.suite/first-link" title="First link">First link</a></li></ul>', $menu->render());
     }
 
 
@@ -129,7 +129,7 @@ class SimpleMenuTest extends PHPUnit_Framework_TestCase
         $this->assertCount(2, $menu->items());
         $this->assertTrue($menu->items()->first()->options('active'));
         $this->assertSame('active', $menu->items()->first()->options('class'));
-        $this->assertSame('<ul><li class="active"><a href="http://test.suite/first-link" title="First link">First link</a></li><li><a href="http://test.suite/second-link" title="Second link">Second link</a></li></ul>', (new UnorderedListPresenter)->render($menu));
+        $this->assertSame('<ul><li class="active"><a href="http://test.suite/first-link" title="First link">First link</a></li><li><a href="http://test.suite/second-link" title="Second link">Second link</a></li></ul>', $menu->render());
     }
 
 


### PR DESCRIPTION
Because we were sorting items before applying a weight, sub menu items were not sorted as expected.

Shift rendering to the menu, so that we can ensure consistency when outputting a sorted list.
